### PR TITLE
Use h2 headers for post titles on archives.

### DIFF
--- a/content.php
+++ b/content.php
@@ -18,9 +18,9 @@
 				<h1 class="entry-title"><?php the_title(); ?></h1>
 			<?php }
 			else { ?>
-				<h1 class="entry-title">
+				<h2 class="entry-title">
 					<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( esc_html__( 'Permalink to %s', 'quark' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a>
-				</h1>
+				</h2>
 			<?php } // is_single() ?>
 			<?php quark_posted_on(); ?>
 			<?php if ( has_post_thumbnail() && !is_search() ) { ?>

--- a/style.css
+++ b/style.css
@@ -805,11 +805,11 @@ select {
 	text-decoration: none;
 }
 
-.entry-header h1 a:visited {
+.entry-header h1 a:visited, .entry-header h2 a:visited {
 	color: #333;
 }
 
-.entry-header h1 a:hover {
+.entry-header h1 a:hover, .entry-header h2 a:hover {
 	color: #2997ab;
 }
 


### PR DESCRIPTION
I am no expert on this, but I've read that, from a SEO perspective the best practice is not to overuse H1 headers within a single page. For this reason I provide this small patch that sets H2 headers on post titles on archive pages instead of H1s.

Nevertheless, I'd highly recommend doing some research yourself about this.

Also, please note that the stylesheet modifications might be incomplete.

Thanks
