### PR TITLE
Removed invalid http-equiv meta tags and send HTTP headers instead.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,6 +14,18 @@
 if ( ! isset( $content_width ) )
 	$content_width = 790; /* Default the embedded content width to 790px */
 
+/**
+ * Send extra HTTP headers for IE compatibility.
+ */
+if ( ! function_exists( 'quark_http_headers' ) ) {
+	function quark_http_headers() {
+		// Always force latest IE rendering engine (even in intranet) & Chrome Frame
+		header('X-UA-Compatible: IE=edge,chrome=1');
+		// IEMobile
+		header('Cleartype: on');
+	}
+}
+add_action( 'send_headers', 'quark_http_headers' );
 
 /**
  * Sets up theme defaults and registers support for various WordPress features.

--- a/header.php
+++ b/header.php
@@ -18,11 +18,8 @@
 
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
-	<!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame -->
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
 	<title><?php wp_title( '|', true, 'right' ); ?></title>
-	<meta http-equiv="cleartype" content="on">
 
 	<!-- Responsive and mobile friendly stuff -->
 	<meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
This patch sends the 'X-UA-Compatible' and 'Cleartype' HTTP headers instead of setting them in 'http-equiv' meta tags, which prevented the theme from getting a pass in W3C Validator.
