### PR TITLE
Use 'span' element to display icons instead of 'i' element.

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,7 +14,7 @@ get_header(); ?>
 
 			<article id="post-0" class="post error404 no-results not-found">
 				<header class="entry-header">
-					<h1 class="entry-title"><i class="fa fa-frown-o fa-lg"></i> <?php esc_html_e( 'Uh Oh! This is somewhat embarrassing!', 'quark' ); ?></h1>
+					<h1 class="entry-title"><span class="fa fa-frown-o fa-lg"></span> <?php esc_html_e( 'Uh Oh! This is somewhat embarrassing!', 'quark' ); ?></h1>
 				</header>
 				<div class="entry-content">
 					<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'quark' ); ?></p>

--- a/author-bio.php
+++ b/author-bio.php
@@ -16,16 +16,16 @@
 		<p><?php the_author_meta( 'description' ); ?></p>
 		<p class="social-meta">
 			<?php if ( get_the_author_meta( 'url' ) ) { ?>
-				<a href="<?php the_author_meta( 'url' ) ?>" title="Website"><i class="fa fa-link fa-fw"></i></a>
+				<a href="<?php the_author_meta( 'url' ) ?>" title="Website"><span class="fa fa-link fa-fw"></span></a>
 			<?php } ?>
 			<?php if ( get_the_author_meta( 'twitter' ) ) { ?>
-				<a href="<?php the_author_meta( 'twitter' ) ?>" title="Twitter"><i class="fa fa-twitter fa-fw"></i></a>
+				<a href="<?php the_author_meta( 'twitter' ) ?>" title="Twitter"><span class="fa fa-twitter fa-fw"></span></a>
 			<?php } ?>
 			<?php if ( get_the_author_meta( 'facebook' ) ) { ?>
-				<a href="<?php the_author_meta( 'facebook' ) ?>" title="Facebook"><i class="fa fa-facebook fa-fw"></i></a>
+				<a href="<?php the_author_meta( 'facebook' ) ?>" title="Facebook"><span class="fa fa-facebook fa-fw"></span></a>
 			<?php } ?>
 			<?php if ( get_the_author_meta( 'googleplus' ) ) { ?>
-				<a href="<?php the_author_meta( 'googleplus' ) ?>" title="Google+"><i class="fa fa-google-plus fa-fw"></i></a>
+				<a href="<?php the_author_meta( 'googleplus' ) ?>" title="Google+"><span class="fa fa-google-plus fa-fw"></span></a>
 			<?php } ?>
 		</p>
 		<div class="author-link">

--- a/content-aside.php
+++ b/content-aside.php
@@ -29,7 +29,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content-audio.php
+++ b/content-audio.php
@@ -39,7 +39,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content-chat.php
+++ b/content-chat.php
@@ -29,6 +29,6 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 	</footer> <!-- /.entry-meta -->
 </article> <!-- /#post -->

--- a/content-gallery.php
+++ b/content-gallery.php
@@ -37,7 +37,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content-image.php
+++ b/content-image.php
@@ -29,7 +29,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content-link.php
+++ b/content-link.php
@@ -29,7 +29,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content-page.php
+++ b/content-page.php
@@ -26,6 +26,6 @@
 		) ); ?>
 	</div><!-- /.entry-content -->
 	<footer class="entry-meta">
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 	</footer><!-- /.entry-meta -->
 </article><!-- /#post -->

--- a/content-postarchives.php
+++ b/content-postarchives.php
@@ -33,6 +33,6 @@
 		<?php wp_link_pages( array( 'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'quark' ), 'after' => '</div>' ) ); ?>
 	</div><!-- /.entry-content -->
 	<footer class="entry-meta">
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 	</footer><!-- /.entry-meta -->
 </article><!-- /#post -->

--- a/content-quote.php
+++ b/content-quote.php
@@ -32,6 +32,6 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 	</footer> <!-- /.entry-meta -->
 </article> <!-- /#post -->

--- a/content-status.php
+++ b/content-status.php
@@ -28,7 +28,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content-video.php
+++ b/content-video.php
@@ -37,7 +37,7 @@
 			// Only show the tags on the Single Post page
 			quark_entry_meta();
 		} ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+		<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 		<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 			// If a user has filled out their description and this is a multi-author blog, show their bio
 			get_template_part( 'author-bio' );

--- a/content.php
+++ b/content.php
@@ -54,7 +54,7 @@
 				// Only show the tags on the Single Post page
 				quark_entry_meta();
 			} ?>
-			<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <i class="fa fa-angle-right"></i>', '<div class="edit-link">', '</div>' ); ?>
+			<?php edit_post_link( esc_html__( 'Edit', 'quark' ) . ' <span class="fa fa-angle-right"></span>', '<div class="edit-link">', '</div>' ); ?>
 			<?php if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) {
 				// If a user has filled out their description and this is a multi-author blog, show their bio
 				get_template_part( 'author-bio' );

--- a/functions.php
+++ b/functions.php
@@ -475,8 +475,8 @@ if ( ! function_exists( 'quark_content_nav' ) ) {
 
 			<?php if ( is_single() ) { // navigation links for single posts ?>
 
-				<?php previous_post_link( '<div class="nav-previous">%link</div>', '<span class="meta-nav">' . _x( '<i class="fa fa-angle-left"></i>', 'Previous post link', 'quark' ) . '</span> %title' ); ?>
-				<?php next_post_link( '<div class="nav-next">%link</div>', '%title <span class="meta-nav">' . _x( '<i class="fa fa-angle-right"></i>', 'Next post link', 'quark' ) . '</span>' ); ?>
+				<?php previous_post_link( '<div class="nav-previous">%link</div>', '<span class="meta-nav">' . _x( '<span class="fa fa-angle-left"></span>', 'Previous post link', 'quark' ) . '</span> %title' ); ?>
+				<?php next_post_link( '<div class="nav-next">%link</div>', '%title <span class="meta-nav">' . _x( '<span class="fa fa-angle-right"></span>', 'Next post link', 'quark' ) . '</span>' ); ?>
 
 			<?php } 
 			elseif ( $wp_query->max_num_pages > 1 && ( is_home() || is_archive() || is_search() ) ) { // navigation links for home, archive, and search pages ?>
@@ -487,9 +487,9 @@ if ( ! function_exists( 'quark_content_nav' ) ) {
 					'current' => max( 1, get_query_var( 'paged' ) ),
 					'total' => $wp_query->max_num_pages,
 					'type' => 'list',
-					'prev_text' => wp_kses( __( '<i class="fa fa-angle-left"></i> Previous', 'quark' ), array( 'i' => array( 
+					'prev_text' => wp_kses( __( '<span class="fa fa-angle-left"></span> Previous', 'quark' ), array( 'span' => array( 
 						'class' => array() ) ) ),
-					'next_text' => wp_kses( __( 'Next <i class="fa fa-angle-right"></i>', 'quark' ), array( 'i' => array( 
+					'next_text' => wp_kses( __( 'Next <span class="fa fa-angle-right"></span>', 'quark' ), array( 'span' => array( 
 						'class' => array() ) ) )
 				) ); ?>
 
@@ -661,7 +661,7 @@ if ( ! function_exists( 'quark_posted_on' ) ) {
 		}
 
 		// Translators: 1: Icon 2: Permalink 3: Post date and time 4: Publish date in ISO format 5: Post date
-		$date = sprintf( '<i class="fa %1$s"></i> <a href="%2$s" title="Posted %3$s" rel="bookmark"><time class="entry-date" datetime="%4$s" pubdate>%5$s</time></a>',
+		$date = sprintf( '<span class="fa %1$s"></span> <a href="%2$s" title="Posted %3$s" rel="bookmark"><time class="entry-date" datetime="%4$s" pubdate>%5$s</time></a>',
 			$post_icon,
 			esc_url( get_permalink() ),
 			sprintf( esc_html__( '%1$s @ %2$s', 'quark' ), esc_html( get_the_date() ), esc_attr( get_the_time() ) ),
@@ -670,7 +670,7 @@ if ( ! function_exists( 'quark_posted_on' ) ) {
 		);
 
 		// Translators: 1: Date link 2: Author link 3: Categories 4: No. of Comments
-		$author = sprintf( '<i class="fa fa-pencil"></i> <address class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></address>',
+		$author = sprintf( '<span class="fa fa-pencil"></span> <address class="author vcard"><a class="url fn n" href="%1$s" title="%2$s" rel="author">%3$s</a></address>',
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 			esc_attr( sprintf( esc_html__( 'View all posts by %s', 'quark' ), get_the_author() ) ),
 			get_the_author()
@@ -680,7 +680,7 @@ if ( ! function_exists( 'quark_posted_on' ) ) {
 		$categories_list = get_the_category_list( esc_html__( ' ', 'quark' ) );
 
 		// Translators: 1: Permalink 2: Title 3: No. of Comments
-		$comments = sprintf( '<span class="comments-link"><i class="fa fa-comment"></i> <a href="%1$s" title="%2$s">%3$s</a></span>',
+		$comments = sprintf( '<span class="comments-link"><span class="fa fa-comment"></span> <a href="%1$s" title="%2$s">%3$s</a></span>',
 			esc_url( get_comments_link() ),
 			esc_attr( esc_html__( 'Comment on ' . the_title_attribute( 'echo=0' ) ) ),
 			( get_comments_number() > 0 ? sprintf( _n( '%1$s Comment', '%1$s Comments', get_comments_number() ), get_comments_number() ) : esc_html__( 'No Comments', 'quark' ) )
@@ -718,7 +718,7 @@ if ( ! function_exists( 'quark_entry_meta' ) ) {
 
 		// Translators: 1 is tag
 		if ( $tag_list ) {
-			printf( wp_kses( __( '<i class="fa fa-tag"></i> %1$s', 'quark' ), array( 'i' => array( 'class' => array() ) ) ), $tag_list );
+			printf( wp_kses( __( '<span class="fa fa-tag"></span> %1$s', 'quark' ), array( 'span' => array( 'class' => array() ) ) ), $tag_list );
 		}
 	}
 }
@@ -877,7 +877,7 @@ if ( ! function_exists( 'quark_get_social_media' ) ) {
 		foreach ( $icons as $key ) {
 			$value = $key['url'];
 			if ( !empty( $value ) ) {
-				$output .= sprintf( '<li><a href="%1$s" title="%2$s"%3$s><span class="fa-stack fa-lg"><i class="fa fa-square fa-stack-2x"></i><i class="fa %4$s fa-stack-1x fa-inverse"></i></span></a></li>',
+				$output .= sprintf( '<li><a href="%1$s" title="%2$s"%3$s><span class="fa-stack fa-lg"><span class="fa fa-square fa-stack-2x"></span><span class="fa %4$s fa-stack-1x fa-inverse"></span></span></a></li>',
 					esc_url( $value ),
 					$key['title'],
 					( !of_get_option( 'social_newtab' ) ? '' : ' target="_blank"' ),

--- a/js/comment-form-validation.js
+++ b/js/comment-form-validation.js
@@ -14,9 +14,9 @@ jQuery( document ).ready( function( $ ) {
 				comment: "required"
 			},
 			messages: {
-				author: '<i class="fa fa-times"></i> ' + comments_object.author,
-				email: '<i class="fa fa-times"></i> ' + comments_object.email,
-				comment: '<i class="fa fa-times"></i> ' + comments_object.comment
+				author: '<span class="fa fa-times"></span> ' + comments_object.author,
+				email: '<span class="fa fa-times"></span> ' + comments_object.email,
+				comment: '<span class="fa fa-times"></span> ' + comments_object.comment
 			}
 		} );
 
@@ -28,7 +28,7 @@ jQuery( document ).ready( function( $ ) {
 				comment: "required"
 			},
 			messages: {
-				comment: '<i class="fa fa-times"></i> ' + comments_object.comment
+				comment: '<span class="fa fa-times"></span> ' + comments_object.comment
 			}
 		} );
 

--- a/languages/quark.pot
+++ b/languages/quark.pot
@@ -245,20 +245,20 @@ msgstr ""
 
 #: ../functions.php:478
 msgctxt "Previous post link"
-msgid "<i class=\"fa fa-angle-left\"></i>"
+msgid "<span class=\"fa fa-angle-left\"></span>"
 msgstr ""
 
 #: ../functions.php:479
 msgctxt "Next post link"
-msgid "<i class=\"fa fa-angle-right\"></i>"
+msgid "<span class=\"fa fa-angle-right\"></span>"
 msgstr ""
 
 #: ../functions.php:490
-msgid "<i class=\"fa fa-angle-left\"></i> Previous"
+msgid "<span class=\"fa fa-angle-left\"></span> Previous"
 msgstr ""
 
 #: ../functions.php:492
-msgid "Next <i class=\"fa fa-angle-right\"></i>"
+msgid "Next <span class=\"fa fa-angle-right\"></span>"
 msgstr ""
 
 #: ../functions.php:529
@@ -341,7 +341,7 @@ msgstr ""
 
 #: ../functions.php:721
 #, php-format
-msgid "<i class=\"fa fa-tag\"></i> %1$s"
+msgid "<span class=\"fa fa-tag\"></span> %1$s"
 msgstr ""
 
 #: ../functions.php:772


### PR DESCRIPTION
This patch replaces the `<i>` elements that are used to display the icons with `<span>` elements.

Scanned the sources for the following (without quotes):
- `"<i "` (ends with space)
- `"</i>"`
- `"'i'"`

If there are more, I'd be glad to know.

Potential users: Please read why this patch was written: http://wordpress.org/support/topic/question-about-the-use-of-the-i-element-to-display-icons
